### PR TITLE
Fix plane prioritization to match QBSP and TrenchBroom behaviour

### DIFF
--- a/src/c/geo_generator.c
+++ b/src/c/geo_generator.c
@@ -372,21 +372,27 @@ vertex_uv get_standard_uv(vec3 vertex, const face *face, int texture_width, int 
 {
     vertex_uv uv_out;
 
+    // Z unit
     double du = fabs(vec3_dot(face->plane_normal, UP_VECTOR));
+    // Y unit
     double dr = fabs(vec3_dot(face->plane_normal, RIGHT_VECTOR));
+    // X unit
     double df = fabs(vec3_dot(face->plane_normal, FORWARD_VECTOR));
 
-    if (du >= dr && du >= df)
+    if (df >= du && df >= dr)
     {
-        uv_out = (vertex_uv){vertex.x, -vertex.y};
+        // X plane.
+        uv_out = (vertex_uv){vertex.y, -vertex.z};
     }
     else if (dr >= du && dr >= df)
     {
+        // Y plane.
         uv_out = (vertex_uv){vertex.x, -vertex.z};
     }
-    else if (df >= du && df >= dr)
+    else
     {
-        uv_out = (vertex_uv){vertex.y, -vertex.z};
+        // Z wins by default.
+        uv_out = (vertex_uv){vertex.x, -vertex.y};
     }
 
     vertex_uv rotated;


### PR DESCRIPTION
See bug discussion in the Discord. https://discord.com/channels/651186754434367500/651225040620224522/874919864115007489

Example bug screenshot using ID E1M1 at https://github.com/ericwa/ericw-tools/tree/master/testmaps/quake_map_source (see the exit area!!!) available on request.

TrenchBroom has been confirmed to render at least horizontal conflicts correctly, so there are likely simpler replication methods.
