### PR TITLE
Fix compilation in gcc10

### DIFF
--- a/src/h/map_data.h
+++ b/src/h/map_data.h
@@ -18,15 +18,15 @@ typedef struct worldspawn_layer
     bool build_visuals;
 } worldspawn_layer;
 
-int entity_count;
-entity *entities;
-entity_geometry *entity_geo;
+extern int entity_count;
+extern entity *entities;
+extern entity_geometry *entity_geo;
 
-int texture_count;
-texture_data *textures;
+extern int texture_count;
+extern texture_data *textures;
 
-int worldspawn_layer_count;
-worldspawn_layer *worldspawn_layers;
+extern int worldspawn_layer_count;
+extern worldspawn_layer *worldspawn_layers;
 
 void map_data_reset();
 


### PR DESCRIPTION
GCC10 changed how globals are handled, so they must be explicitly made extern now or else it will fail to compile.

This also fixes compiling on whatever version llvm started matching gcc10's vehaviour.

Source of the change: https://gcc.gnu.org/gcc-10/porting_to.html

It could also be fixed by adding the -fcommon flag to the compiler but this one seemed like a better solution IMO